### PR TITLE
update to wireshark 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can use the `minecraft` filter to only display minecraft packets
 
 ```bash
 apt install make gcc pkg-config wireshark-dev nodejs # Ubuntu
-nix-shell -p gnumake wireshark.dev pkgconfig glib.dev nodejs-14_x # Nixos
+nix-shell -p gnumake wireshark.dev pkg-config glib.dev nodejs_22 libgcrypt # Nixos
 ```
 
 ### Clone and compile

--- a/packet-minecraft.c
+++ b/packet-minecraft.c
@@ -1,4 +1,4 @@
-#include <config.h>
+#include <ws_version.h>
 
 #define WS_BUILD_DLL
 
@@ -15,8 +15,8 @@
 #include <stdint.h>
 
 WS_DLL_PUBLIC_DEF const gchar plugin_version[] = "0.0.0";
-WS_DLL_PUBLIC_DEF const int plugin_want_major = VERSION_MAJOR;
-WS_DLL_PUBLIC_DEF const int plugin_want_minor = VERSION_MINOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_major = WIRESHARK_VERSION_MAJOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_minor = WIRESHARK_VERSION_MINOR;
 
 WS_DLL_PUBLIC void plugin_register(void);
 


### PR DESCRIPTION
This pr makes this plugin build with wireshark 4 and updates the nix-shell command in the README.

Fixes: #6 